### PR TITLE
Repair `make checks|test` targets

### DIFF
--- a/lambda/Makefile
+++ b/lambda/Makefile
@@ -18,7 +18,7 @@ test: checks
 checks: clean
 	echo "⏳ running pipeline..."
 	set -e
-	isort --atomic -yq
+	isort --atomic -q .
 	black -q .
 	flake8 . --max-line-length=91
 	mypy --warn-unused-config \

--- a/lambda/audit.py
+++ b/lambda/audit.py
@@ -6,10 +6,10 @@ from typing import Any, Dict, Optional, Union
 
 import boto3
 from botocore.exceptions import ClientError  # type: ignore
+from mypy_boto3_sns import SNSClient
 
 import github_api
 from logger import LOG
-from mypy_boto3_sns import SNSClient
 
 
 def start(_message: Dict[str, Any]) -> None:

--- a/lambda/config.py
+++ b/lambda/config.py
@@ -2,9 +2,9 @@ from typing import Dict, Optional
 
 import boto3
 from botocore.exceptions import ClientError  # type: ignore
+from mypy_boto3_ssm import SSMClient
 
 from logger import LOG
-from mypy_boto3_ssm import SSMClient
 
 
 def get_ssm_param(param: str) -> Optional[str]:

--- a/lambda/tests/test_audit.py
+++ b/lambda/tests/test_audit.py
@@ -2,9 +2,9 @@ import json
 import os
 
 import pytest
+import stubs
 
 import audit
-import stubs
 
 
 @pytest.mark.usefixtures("event_body")

--- a/lambda/tests/test_config.py
+++ b/lambda/tests/test_config.py
@@ -1,4 +1,5 @@
 import stubs
+
 from config import get_ssm_params
 from github_usage import TOKEN_PREFIX
 

--- a/lambda/tests/test_github_api.py
+++ b/lambda/tests/test_github_api.py
@@ -1,8 +1,8 @@
 import json
 
 import pytest
-
 import requests_mock
+
 from github_api import (
     get_github_org_members,
     get_member_logins,

--- a/lambda/tests/test_github_usage.py
+++ b/lambda/tests/test_github_usage.py
@@ -2,9 +2,9 @@
 import os
 
 import pytest
-
 import requests_mock
 import stubs
+
 from github_api import set_github_access_token
 from github_usage import process_message, usage
 


### PR DESCRIPTION
- isort doesn't recognise argument -y
- for some reason I had to add `#type: ignore` to conftest.py:4 (`import pytest`)
- and then it objected to that so I removed it and now it works?