### PR TITLE
Move boto stubs in to runtime requirements.txt

### DIFF
--- a/lambda/requirements-dev.txt
+++ b/lambda/requirements-dev.txt
@@ -6,4 +6,3 @@ pylint
 flake8
 requests_mock
 mypy
-boto3-stubs[sns, ssm, sqs]

--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,2 +1,3 @@
 boto3
+boto3-stubs[sns, ssm, sqs]
 requests


### PR DESCRIPTION
this means they get included in the lambda package for the runtime