### PR TITLE
Use different statement ids for the allow execution statements

### DIFF
--- a/terraform/deployable/github_usage_lambda.tf
+++ b/terraform/deployable/github_usage_lambda.tf
@@ -46,7 +46,7 @@ resource "aws_cloudwatch_event_target" "run_usage_every_x_minutes" {
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_invoke_usage_lambda" {
   count         = var.usage_cron_schedule == "" ? 0 : 1
-  statement_id  = "AllowExecutionFromCloudWatch"
+  statement_id  = "AllowUsageExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.github_usage_lambda.function_name
   principal     = "events.amazonaws.com"
@@ -78,7 +78,7 @@ resource "aws_cloudwatch_event_target" "run_audit_every_x_minutes" {
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_invoke_audit_lambda" {
   count         = var.audit_cron_schedule == "" ? 0 : 1
-  statement_id  = "AllowExecutionFromCloudWatch"
+  statement_id  = "AllowAuditExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.github_usage_lambda.function_name
   principal     = "events.amazonaws.com"


### PR DESCRIPTION
I assumed that this was creating 2 separate polices but it looks like it must be creating statements in a shared policy.

Invocation from CloudWatch is only enabled if there's a cron schedule set up. I've removed the cron schedule from non-prod but we can still test by manually invoking the lambda.