### PR TITLE
Reinstate TypeError catch in event_parser

### DIFF
--- a/lambda/event_parser.py
+++ b/lambda/event_parser.py
@@ -17,7 +17,7 @@ def get_message_body(message: Dict[str, Any]) -> Any:
 
     try:
         message_body = json.loads(message_text)
-    except (json.JSONDecodeError):
+    except (TypeError, json.JSONDecodeError):
         message_body = message_text
 
     return message_body


### PR DESCRIPTION
This is there to catch things which have already been json decoded.

I've manually deployed to `security-test` and invoked from the CLI and it now works.