### PR TITLE
Fix runtime, logger and error handling for functions with no return.

### DIFF
--- a/lambda/Makefile
+++ b/lambda/Makefile
@@ -18,9 +18,13 @@ test: checks
 checks: clean
 	echo "⏳ running pipeline..."
 	set -e
+	echo "isorting"
 	isort --atomic -q .
+	echo "blacking"
 	black -q .
+	echo "flake8ing"
 	flake8 . --max-line-length=91
+	echo "mypying"
 	mypy --warn-unused-config \
              --disallow-any-generics \
              --disallow-subclassing-any \

--- a/lambda/audit.py
+++ b/lambda/audit.py
@@ -1,7 +1,6 @@
 import json
 import os
 import uuid
-from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 
 import boto3
@@ -12,7 +11,7 @@ import github_api
 from logger import LOG
 
 
-def start(_message: Dict[str, Any]) -> None:
+def start(message: Dict[str, Any]) -> None:
     """
     Start an audit of github membership
 
@@ -290,17 +289,6 @@ def publish_alert(audit_id: str, message: str) -> Any:
         return None
 
 
-@dataclass
-class AuditEvent:
-    type: Optional[str]
-    org: Optional[str]
-    member: Optional[Dict[str, Any]]
-    team: Optional[Dict[str, Any]]
-    repository: Optional[Dict[str, Any]]
-    count: int
-    audit_id: Optional[str]
-
-
 def make_audit_event(
     type: Optional[str] = None,
     org: Optional[str] = None,
@@ -309,14 +297,14 @@ def make_audit_event(
     repository: Optional[Dict[str, Any]] = None,
     count: int = 0,
     audit_id: Optional[str] = None,
-) -> AuditEvent:
+) -> Dict[str, Any]:
     """
     Create an audit event dictionary with a fixed data model
 
     Converts arguments to a dictionary.
     The Nones should be present in the dictionary.
     """
-    return AuditEvent(type, org, member, team, repository, count, audit_id)
+    return locals()
 
 
 def send_sns_trigger(
@@ -325,13 +313,14 @@ def send_sns_trigger(
     repo: Optional[Dict[str, Any]] = None,
     team: Optional[Dict[str, Any]] = None,
     audit_id: str = "",
-) -> None:
+) -> Any:
     """
     Create the SNS payload to trigger the next lambda invovation
     """
     event = locals()
     payload = create_sns_message(audit_id, event)
     response = publish_alert(audit_id, payload)
+    return response
 
 
 class IncompleteAuditError(Exception):

--- a/lambda/event_parser.py
+++ b/lambda/event_parser.py
@@ -2,9 +2,12 @@
 import json
 from typing import Any, Dict, List
 
+from logger import LOG
+
 
 def get_message_body(message: Dict[str, Any]) -> Any:
     """ Return json decoded message body from either SNS or SQS event model """
+    LOG.debug("Message: " + str(message))
     if "body" in message:
         message_text = message.get("body", "")
     elif (
@@ -27,6 +30,7 @@ def parse_messages(event: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
     Parse the escaped message body from each of the SQS messages in event.Records
     """
+    LOG.debug(str(event))
     use_default = False
     if "Records" in event:
         messages = [get_message_body(record) for record in event["Records"]]

--- a/lambda/github_usage.py
+++ b/lambda/github_usage.py
@@ -29,25 +29,28 @@ def process_message(message: Dict[str, Any]) -> Any:
     """
     Receive event body forwarded from lambda handler.
     """
-    actions = {
-        "register": register,
-        "commit": commit,
-        "usage": usage,
-        "audit": audit.start,
-        "log_org_membership": audit.log_org_membership,
-        "log_org_teams": audit.log_org_teams,
-        "log_org_team_membership": audit.log_org_team_membership,
-        "log_org_team_repos": audit.log_org_team_repos,
-        "log_org_repos": audit.log_org_repos,
-        "log_org_repo_contributors": audit.log_org_repo_contributors,
-        "log_org_repo_team_members": audit.log_org_repo_team_members,
-    }
-    action = message["action"]
+    try:
+        actions = {
+            "register": register,
+            "commit": commit,
+            "usage": usage,
+            "audit": audit.start,
+            "log_org_membership": audit.log_org_membership,
+            "log_org_teams": audit.log_org_teams,
+            "log_org_team_membership": audit.log_org_team_membership,
+            "log_org_team_repos": audit.log_org_team_repos,
+            "log_org_repos": audit.log_org_repos,
+            "log_org_repo_contributors": audit.log_org_repo_contributors,
+            "log_org_repo_team_members": audit.log_org_repo_team_members,
+        }
+        action = message["action"]
 
-    process_action = actions[action]
-    success = process_action(message)
-    if not success:
-        LOG.error("Processing failed for %s", action)
+        process_action = actions[action]
+        success = process_action(message)
+        if not success:
+            LOG.error("Processing failed for %s", action)
+    except (audit.IncompleteAuditError, github_api.GithubApiError):
+        success = False
     return success
 
 

--- a/lambda/logger.py
+++ b/lambda/logger.py
@@ -4,41 +4,31 @@ import json
 import logging
 import os
 import sys
-from dataclasses import asdict, is_dataclass
 
 
 class JsonFormatter(logging.Formatter):
-    """ Handle log invokes with string, dict or json.dumps """
+    """
+    Handle log invokes with string, dict or json.dumps
+    """
 
-    def format(self, record: logging.LogRecord) -> str:
+    def format(self) -> str:  # type: ignore
         """ Detect formatting of self message and encode as valid JSON """
-
         data = {}
-        data.update(vars(record))
-
-        # If the data['msg'] is valid JSON, convert it to python dict
-        # so it can be embedded in output as a nested dict instead of
-        # a JSON string.
+        data.update(vars(self))
         try:
-            parsed = json.loads(data["msg"])
-            data["msg"] = parsed
+            json.loads(self.msg)  # type: ignore
+            parsed = json.loads(self.msg)  # type: ignore
+            if type(parsed) in [dict, list]:
+                data["msg"] = parsed
         except (TypeError, ValueError):
             pass
 
-        # If data['msg'] is a dataclass convert it to a dict otherwise
-        # JSON serialisation will fail.
-        if is_dataclass(data["msg"]):
-            data["msg"] = asdict(data["msg"])
-
-        # If data['args'] is provided, use msg['data'] as a format
-        # template and data['args'] as the variables. If the
-        # number of template placeholders does not match the number of
-        # args, this will fail.
-        if ("args" in data) and len(data["args"]) > 0:
-            try:
-                data["msg"] = data["msg"] % tuple(data["args"])
-            except TypeError:
-                pass
+        try:
+            if ("args" in data) and len(data["args"]) > 0:
+                args = data["args"]
+                data["msg"] = data["msg"] % args
+        except TypeError:
+            pass
 
         data["timestamp"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
@@ -49,16 +39,12 @@ def build_logger(log_name: str, log_level: str = "ERROR") -> logging.Logger:
     """ Create shared logger and custom JSON handler """
     logger = logging.getLogger(log_name)
     handler = logging.StreamHandler(sys.stdout)
-
-    # //if isinstance(JsonFormatter, logging.Formatter):
-    fmt = JsonFormatter()
-    handler.setFormatter(fmt)
-
+    handler.setFormatter(JsonFormatter)  # type: ignore
     logger.handlers = []
     logger.addHandler(handler)
-    logger.setLevel(logging.ERROR)
+    logger.setLevel(getattr(logging, log_level))
     return logger
 
 
-LOG_LEVEL = str(os.getenv("LOG_LEVEL", "DEBUG"))
+LOG_LEVEL = str(os.getenv("LOG_LEVEL", "ERROR"))
 LOG = build_logger("github_usage", log_level=LOG_LEVEL)

--- a/lambda/tests/test_audit.py
+++ b/lambda/tests/test_audit.py
@@ -41,18 +41,18 @@ def test_make_audit_event():
     test_event = {"type": "Test", "org": "alphagov", "count": 12}
 
     event = audit.make_audit_event(type=test_event["type"])
-    assert event.type == test_event["type"]
+    assert event["type"] == test_event["type"]
     # Check the org key is present but None
-    assert event.org is None
+    assert event["org"] is None
 
     event = audit.make_audit_event(type=test_event["type"], org=test_event["org"])
-    assert event.type == test_event["type"]
-    assert event.org == test_event["org"]
+    assert event["type"] == test_event["type"]
+    assert event["org"] == test_event["org"]
     # Check the repository key is present but None
-    assert event.repository is None
+    assert event["repository"] is None
 
     event = audit.make_audit_event(
         type=test_event["type"], org=test_event["org"], count=test_event["count"]
     )
-    assert event.count == 12
-    assert event.member is None
+    assert event["count"] == 12
+    assert event["member"] is None

--- a/terraform/deployable/log_subscription.tf
+++ b/terraform/deployable/log_subscription.tf
@@ -1,6 +1,6 @@
 module "log_subscription" {
   source = "git::ssh://git@github.com/alphagov/cyber-security-terraform//modules/csls_cloudwatch_log_group_subscription?ref=d4e012260bb8d8a42ccdc6dbc1691eeaf8933a99"
   log_groups = {
-    "/aws/lambda/github_usage_lambda" : "INFO"
+    "/aws/lambda/github_usage_lambda" : "?INFO ?ERROR"
   }
 }


### PR DESCRIPTION
Add exception type and catch for GithubApiErrors and
catch IncompleteAuditErrors
Subscribe info and error messages to Splunk.

This fixes the runtime and adds a few mypy ignores to get it working. I think we should merge this to get it working and then address issues on a separate PR. 

I have reverted to logging a dict instead of the AuditEvent object because the logging module doesn't currently know how to log a custom object. I'll raise that as a new issue.