### PR TITLE
Set default log level to INFO

### DIFF
--- a/terraform/deployable/variables.tf
+++ b/terraform/deployable/variables.tf
@@ -16,7 +16,7 @@ variable "GITHUB_TOKEN" {
 variable "LOG_LEVEL" {
   description = "Set the lambda log level"
   type        = string
-  default     = "ERROR"
+  default     = "INFO"
 }
 
 variable "usage_cron_schedule" {


### PR DESCRIPTION
I got the log levels the wrong way round and set the default log level to ERROR which meant prod wasn't logging INFO messages. Test was explicitly set to DEBUG so it was working. 