### PR TITLE
CE-378 Pass optional params argument to github API

### DIFF
--- a/lambda/audit.py
+++ b/lambda/audit.py
@@ -67,10 +67,7 @@ def log_org_teams(message: Dict[str, Any]) -> None:
             )
             LOG.info(event)
             send_sns_trigger(
-                action="log_org_team_membership",
-                org=org,
-                team=team,
-                audit_id=audit_id,
+                action="log_org_team_membership", org=org, team=team, audit_id=audit_id,
             )
 
             send_sns_trigger(
@@ -110,9 +107,7 @@ def log_org_team_membership(message: Dict[str, Any]) -> None:
                 LOG.info(event)
         else:
             raise IncompleteAuditError(
-                audit_id=audit_id,
-                source=message,
-                message="Team not specified",
+                audit_id=audit_id, source=message, message="Team not specified",
             )
 
 
@@ -154,9 +149,7 @@ def log_org_team_repos(message: Dict[str, Any]) -> None:
                 )
         else:
             raise IncompleteAuditError(
-                audit_id=audit_id,
-                source=message,
-                message="Missing parameter",
+                audit_id=audit_id, source=message, message="Missing parameter",
             )
 
 

--- a/lambda/github_api.py
+++ b/lambda/github_api.py
@@ -27,7 +27,12 @@ def get_github_access_token() -> Optional[str]:
     return ACCESS_TOKEN
 
 
-def get_github_api_paged_data(url: str) -> List[Any]:
+def get_github_api_paged_data(url: str, params: Dict[str, str] = {}) -> List[Any]:
+    """
+    Iterate through all available pages for endpoint
+
+    Optional query string parameters as 2nd argument
+    """
     token = get_github_access_token()
     page = 1
     page_size = 100
@@ -37,7 +42,7 @@ def get_github_api_paged_data(url: str) -> List[Any]:
         page_items = 0
         page_url = f"{url}?page={page}&per_page={page_size}"
         headers = {"authorization": f"token {token}"}
-        response = requests.get(page_url, headers=headers)
+        response = requests.get(page_url, params=params, headers=headers)
 
         if response.status_code == 200:
             response_items = response.json()
@@ -104,8 +109,8 @@ def get_github_org_repo_contributors(org: str, repo: str) -> List[Dict[str, str]
     # The ?affiliation=direct query string lists only users who have
     # direct access - This is important for the leavers process since it will
     # persist after the user leaves the alphagov membership
-    url = f"{API_ROOT}/repos/{org}/{repo}/contributors?affiliation=direct"
-    contributors = get_github_api_paged_data(url)
+    url = f"{API_ROOT}/repos/{org}/{repo}/contributors"
+    contributors = get_github_api_paged_data(url, {"affiliation": "direct"})
     return contributors
 
 
@@ -120,8 +125,7 @@ class GithubApiError(Exception):
     """
 
     def __init__(
-        self,
-        message: Union[str, TypeError] = "Incomplete audit error",
+        self, message: Union[str, TypeError] = "Incomplete audit error",
     ):
         self.message = message
         super().__init__(self.message)

--- a/lambda/tests/stubs.py
+++ b/lambda/tests/stubs.py
@@ -147,15 +147,11 @@ def mock_ssm_usage():
     )
 
     stubber.add_response(
-        "delete_parameter",
-        {},
-        {"Name": "/alert-processor/tokens/github/user-a"},
+        "delete_parameter", {}, {"Name": "/alert-processor/tokens/github/user-a"},
     )
 
     stubber.add_response(
-        "delete_parameter",
-        {},
-        {"Name": "/alert-processor/tokens/github/user-b"},
+        "delete_parameter", {}, {"Name": "/alert-processor/tokens/github/user-b"},
     )
 
     stubber.activate()


### PR DESCRIPTION
Previously I had passed the query string encoded in the URL. This uses the requests get params arg to pass a dict of query string parameters. 

Plus minor black linting changes to code layout